### PR TITLE
Added color swatches to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ FORE_PRIMARY   = '#FFFFFF';
 FORE_SECONDARY = '#1ED760';
 ```
 
+|      BACK_PRIMARY     |      BACK_SECONDARY     |      BACK_HIGHLIGHT     |      FORE_PRIMARY     |      FORE_SECONDARY     |
+|-----------------------|-------------------------|-------------------------|-----------------------|-------------------------|
+| ![BACK_PRIMARY_IMG][] | ![BACK_SECONDARY_IMG][] | ![BACK_HIGHLIGHT_IMG][] | ![FORE_PRIMARY_IMG][] | ![FORE_SECONDARY_IMG][] |
+
+[BACK_PRIMARY_IMG]: https://img.shields.io/badge/%23222326-%20%20%20-222326.svg
+[BACK_SECONDARY_IMG]: https://img.shields.io/badge/%23121314-%20%20%20-121314.svg
+[BACK_HIGHLIGHT_IMG]: https://img.shields.io/badge/%23615F59-%20%20%20-615F59.svg
+[FORE_PRIMARY_IMG]: https://img.shields.io/badge/%23FFFFFF-%20%20%20-FFFFFF.svg
+[FORE_SECONDARY_IMG]: https://img.shields.io/badge/%231ED760-%20%20%20-1ED760.svg
+
 ## Color Format
 When changing colors you can use **ANY** CSS standard color syntax.  `#`, `rgb()`, `rgba()` Etc.
 


### PR DESCRIPTION
While discussing #17 I was getting frustrated at not having a good point of reference for what colors were which in the UI. To resolve this, I have added color swatches to the README.

I wanted to use HTML with `style="background"` or SVG but it looks like GitHub scrubs those. Thankfully, I was able to find a workaround via Shields.io (a badge service).

![selection_004](https://cloud.githubusercontent.com/assets/902488/13710950/a4703baa-e781-11e5-9d9f-9e518a8371e6.png)

In this PR:
- Added color swatches to README

/cc @gmusic-utils/gmusic-theme-js 
