### PR TITLE
Added package.json description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gmusic-theme.js",
-  "description": "",
+  "description": "Browser-side JS library for theming Google Music",
   "version": "1.0.17",
   "homepage": "https://github.com/gmusic-utils/gmusic-theme.js#readme",
   "author": {


### PR DESCRIPTION
A tiny change to fix an annoyance on npm.

Added a package.json description so that it has something to show as the tagline.  Right now it looks to be using the first few sentences of text, which is just a block of html from the shields

https://www.npmjs.com/package/gmusic-theme.js

<img width="826" alt="screenshot 2016-03-12 10 07 02" src="https://cloud.githubusercontent.com/assets/319883/13722344/31ad1cd2-e83a-11e5-9299-599a125e7313.png">
