### PR TITLE
Added themed Text Highlighting

### DIFF
--- a/lib/common.css
+++ b/lib/common.css
@@ -206,3 +206,7 @@ button.goog-buttonset-default:hover {
 .material .sj-play-button-0 #pulse.sj-play-button {
     background: <<ALPHA 0.5>><<FORE_SECONDARY>><<ALPHA>>;
 }
+/**Text Highlighing **/
+paper-dialog input::selection, paper-dialog textarea::selection {
+	background:<<ALPHA 0.6>><<FORE_SECONDARY>><</ALPHA>>;
+}


### PR DESCRIPTION
This adds theming to Text highlighting within the Edit section of GPM...
I'm fine if it shouldn't be accepted as it's a strange thing which might not work well with all theme colours.
Also Alpha might need tweaking... It's slightly darker.

Before: http://puu.sh/s0zEE/0d209f5b09.png
After: http://puu.sh/s0zA0/04d1e290fe.png

Bright colour: http://puu.sh/s0TR7/544428caf9.png
Dark colour: http://puu.sh/s0TWx/3bff8b72b9.png
