### PR TITLE
Fixed loading spinner for playlist

### DIFF
--- a/lib/full.css
+++ b/lib/full.css
@@ -675,3 +675,9 @@ gpm-card-grid > [slot="title"] {
 ::shadow ::-webkit-scrollbar-thumb:active {
   background-color: rgba(255, 255, 255, 0.125);
 }
+
+/* Fix loading spinner on playlist dot menu */
+.goog-menuheader .spinner {
+    background: <<BACK_PRIMARY>> url(ani_loading_white.gif) no-repeat center center;
+    background-size: 30px 30px;
+}


### PR DESCRIPTION
![image](https://puu.sh/xWbMc/7c65187557.gif)
The Background-size is because of the white version is for some reason is larger at 48\*48px compared to the white's 40\*40pxs
Fixes #75 